### PR TITLE
refactor: add version to connection error

### DIFF
--- a/backend/src/common/axios/axios.service.ts
+++ b/backend/src/common/axios/axios.service.ts
@@ -24,6 +24,7 @@ import {
 } from '@remnawave/backend-contract';
 
 import { IGNORED_HEADERS } from '@common/constants';
+import { getAppVersion } from '@common/utils/startup-app';
 
 import { ICommandResponse } from '../types/command-response.type';
 
@@ -75,11 +76,12 @@ export class AxiosService implements OnModuleInit {
 
         const remnawaveMetadata = await this.getRemnawaveMetadata();
         if (!remnawaveMetadata.isOk || !remnawaveMetadata.remnawaveVersion) {
+            const appVersion = await getAppVersion();
             this.logger.error(
                 '\n' +
-                    table([['Is the panel online and reachable from this server?']], {
+                    table([['Connection to Remnawave Panel failed!\nIs the panel online and reachable from this server?']], {
                         header: {
-                            content: `Connection to Remnawave Panel failed!`,
+                            content: `Remnawave Subscription Page v${appVersion}`,
                             alignment: 'center',
                         },
                         columnDefault: {
@@ -206,9 +208,10 @@ export class AxiosService implements OnModuleInit {
         } catch (error) {
             if (error instanceof AxiosError) {
                 if (error.response?.status === 404) {
+                    const appVersion = await getAppVersion();
                     this.logger.error('Request failed with 404 status code.');
                     this.logger.error(
-                        'This version of Subscription Page requires Remnawave Panel version >=2.4.0. Please upgrade Remnawave Panel to the latest version or downgrade Subscription Page.',
+                        `Subscription Page v${appVersion} requires Remnawave Panel version >=2.4.0. Please upgrade Remnawave Panel to the latest version or downgrade Subscription Page.`,
                     );
                     return { isOk: false };
                 }

--- a/backend/src/common/utils/startup-app/get-app-version.ts
+++ b/backend/src/common/utils/startup-app/get-app-version.ts
@@ -1,0 +1,14 @@
+import { readPackageJSON } from 'pkg-types';
+
+let cachedVersion: string | undefined;
+
+export async function getAppVersion(): Promise<string> {
+    if (cachedVersion) {
+        return cachedVersion;
+    }
+
+    const pkg = await readPackageJSON();
+    cachedVersion = pkg.version ?? 'unknown';
+    return cachedVersion;
+}
+

--- a/backend/src/common/utils/startup-app/get-start-message.ts
+++ b/backend/src/common/utils/startup-app/get-start-message.ts
@@ -1,12 +1,12 @@
-import { getBorderCharacters, table } from 'table';
-import { readPackageJSON } from 'pkg-types';
+import { table } from 'table';
+import { getAppVersion } from './get-app-version';
 
 export async function getStartMessage() {
-    const pkg = await readPackageJSON();
+    const appVersion = await getAppVersion();
 
     return table([['Docs → https://docs.rw\nCommunity → https://t.me/remnawave']], {
         header: {
-            content: `Remnawave Subscription Page v${pkg.version}`,
+            content: `Remnawave Subscription Page v${appVersion}`,
             alignment: 'center',
         },
         columnDefault: {
@@ -17,6 +17,5 @@ export async function getStartMessage() {
             1: { alignment: 'center' },
         },
         drawVerticalLine: () => false,
-        border: getBorderCharacters('ramac'),
     });
 }

--- a/backend/src/common/utils/startup-app/index.ts
+++ b/backend/src/common/utils/startup-app/index.ts
@@ -1,3 +1,4 @@
 export * from './get-start-message';
+export * from './get-app-version';
 export * from './init-log.util';
 export * from './is-development';


### PR DESCRIPTION
Currently, if the sub page fails to run, you wouldn't be able to to know which version even is it from the logs. I believe you should.  