### PR TITLE
feat: add Happ crypt5 link support

### DIFF
--- a/backend/src/modules/root/root.controller.ts
+++ b/backend/src/modules/root/root.controller.ts
@@ -1,6 +1,17 @@
-import { Request, Response } from 'express';
+import { Request, Response as ExpressResponse } from 'express';
 
-import { Get, Controller, Res, Req, Param, Logger } from '@nestjs/common';
+import {
+    BadGatewayException,
+    BadRequestException,
+    Body,
+    Controller,
+    Get,
+    Logger,
+    Param,
+    Post,
+    Req,
+    Res,
+} from '@nestjs/common';
 
 import {
     REQUEST_TEMPLATE_TYPE_VALUES,
@@ -14,6 +25,9 @@ import { IJwtPayload } from '@common/constants';
 
 import { SubpageConfigService } from './subpage-config.service';
 import { RootService } from './root.service';
+
+const HAPP_CRYPT5_API_URL = 'https://crypto.happ.su/api-v2.php';
+const HAPP_CRYPT5_TIMEOUT_MS = 10_000;
 
 @Controller()
 export class RootController {
@@ -29,11 +43,78 @@ export class RootController {
         return await this.subpageConfigService.getSubscriptionPageConfig(user.su, request);
     }
 
+    @Post(':shortUuid/happ-crypt5')
+    async createHappCrypt5Link(@Body('url') url: unknown) {
+        if (typeof url !== 'string' || !/^https?:\/\//.test(url)) {
+            throw new BadRequestException('Invalid subscription URL');
+        }
+
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), HAPP_CRYPT5_TIMEOUT_MS);
+
+        let response: globalThis.Response;
+
+        try {
+            response = await fetch(HAPP_CRYPT5_API_URL, {
+                method: 'POST',
+                headers: {
+                    Accept: 'application/json, text/plain;q=0.9, */*;q=0.8',
+                    'Content-Type': 'application/json',
+                    'User-Agent': 'remnawave-subscription-page/1.0',
+                },
+                body: JSON.stringify({ url }),
+                signal: controller.signal,
+            });
+        } catch (error) {
+            throw new BadGatewayException(
+                error instanceof Error
+                    ? `Happ crypt5 API request failed: ${error.message}`
+                    : 'Happ crypt5 API request failed',
+            );
+        } finally {
+            clearTimeout(timeout);
+        }
+
+        const rawResponse = await response.text();
+
+        if (!response.ok) {
+            throw new BadGatewayException(
+                `Happ crypt5 API responded with ${response.status}: ${rawResponse.slice(0, 300)}`,
+            );
+        }
+
+        let link: unknown = rawResponse.trim();
+        const contentType = response.headers.get('content-type');
+
+        if (contentType?.includes('application/json')) {
+            try {
+                const data: unknown = JSON.parse(rawResponse);
+
+                if (typeof data === 'string') {
+                    link = data;
+                } else if (data && typeof data === 'object') {
+                    const payload = data as Record<string, unknown>;
+                    link = payload.encrypted_link ?? payload.url ?? payload.link ?? payload.result;
+                }
+            } catch {
+                link = rawResponse.trim();
+            }
+        }
+
+        if (typeof link !== 'string' || !link.startsWith('happ://crypt5/')) {
+            throw new BadGatewayException(
+                `Happ crypt5 API returned an invalid link: ${rawResponse.slice(0, 300)}`,
+            );
+        }
+
+        return { link };
+    }
+
     @Get([':shortUuid', ':shortUuid/:clientType'])
     async root(
         @ClientIp() clientIp: string,
         @Req() request: Request,
-        @Res() response: Response,
+        @Res() response: ExpressResponse,
         @Param('shortUuid') shortUuid: string,
         @Param('clientType') clientType: string,
     ) {

--- a/backend/src/modules/root/root.controller.ts
+++ b/backend/src/modules/root/root.controller.ts
@@ -44,9 +44,28 @@ export class RootController {
     }
 
     @Post(':shortUuid/happ-crypt5')
-    async createHappCrypt5Link(@Body('url') url: unknown) {
+    async createHappCrypt5Link(
+        @Param('shortUuid') shortUuid: string,
+        @Req() request: Request,
+        @Body('url') url: unknown,
+    ) {
         if (typeof url !== 'string' || !/^https?:\/\//.test(url)) {
             throw new BadRequestException('Invalid subscription URL');
+        }
+
+        const subscriptionUrl = new URL(url);
+        const expectedHost = request.get('host');
+        const forwardedProto = request.get('x-forwarded-proto')?.split(',')[0]?.trim();
+        const expectedProtocol = forwardedProto || request.protocol;
+        const expectedOrigin = expectedHost ? `${expectedProtocol}://${expectedHost}` : undefined;
+        const lastPathSegment = subscriptionUrl.pathname.split('/').filter(Boolean).at(-1);
+
+        if (expectedOrigin && subscriptionUrl.origin !== expectedOrigin) {
+            throw new BadRequestException('Subscription URL origin mismatch');
+        }
+
+        if (lastPathSegment !== shortUuid) {
+            throw new BadRequestException('Subscription URL short UUID mismatch');
         }
 
         const controller = new AbortController();
@@ -66,11 +85,12 @@ export class RootController {
                 signal: controller.signal,
             });
         } catch (error) {
-            throw new BadGatewayException(
+            this.logger.warn(
                 error instanceof Error
                     ? `Happ crypt5 API request failed: ${error.message}`
                     : 'Happ crypt5 API request failed',
             );
+            throw new BadGatewayException('Happ crypt5 API request failed');
         } finally {
             clearTimeout(timeout);
         }
@@ -78,9 +98,10 @@ export class RootController {
         const rawResponse = await response.text();
 
         if (!response.ok) {
-            throw new BadGatewayException(
+            this.logger.warn(
                 `Happ crypt5 API responded with ${response.status}: ${rawResponse.slice(0, 300)}`,
             );
+            throw new BadGatewayException('Happ crypt5 API request failed');
         }
 
         let link: unknown = rawResponse.trim();
@@ -102,9 +123,8 @@ export class RootController {
         }
 
         if (typeof link !== 'string' || !link.startsWith('happ://crypt5/')) {
-            throw new BadGatewayException(
-                `Happ crypt5 API returned an invalid link: ${rawResponse.slice(0, 300)}`,
-            );
+            this.logger.warn(`Happ crypt5 API returned an invalid link: ${rawResponse.slice(0, 300)}`);
+            throw new BadGatewayException('Happ crypt5 API returned an invalid link');
         }
 
         return { link };

--- a/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
+++ b/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
@@ -17,6 +17,7 @@ import {
 import { notifications } from '@mantine/notifications'
 import { useClipboard } from '@mantine/hooks'
 import { useState } from 'react'
+import { joinURL } from 'ufo'
 import clsx from 'clsx'
 
 import { constructSubscriptionUrl } from '@shared/utils/construct-subscription-url'
@@ -32,11 +33,53 @@ import classes from './installation-guide.module.css'
 
 export type TBlockVariant = 'accordion' | 'cards' | 'minimal' | 'timeline'
 
+const HAPP_CRYPT5_BUTTON_TYPES = new Set(['HAPP_CRYPT5_LINK', 'happCrypt5Link'])
+const HAPP_CRYPT5_TEMPLATE = '{{HAPP_CRYPT5_LINK}}'
+
 interface IProps {
     BlockRenderer: React.ComponentType<IBlockRendererProps>
     hasPlatformApps: Record<TSubscriptionPagePlatformKey, boolean>
     isMobile: boolean
     platform: TSubscriptionPagePlatformKey | undefined
+}
+
+function getButtonType(button: TSubscriptionPageButtonConfig): string {
+    return String(button.type)
+}
+
+function getButtonLinkTemplate(button: TSubscriptionPageButtonConfig): string | undefined {
+    if ('link' in button && typeof button.link === 'string') {
+        return button.link
+    }
+
+    return undefined
+}
+
+async function createHappCrypt5Link(apiUrl: string, url: string): Promise<string> {
+    const response = await fetch(apiUrl, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ url })
+    })
+
+    if (!response.ok) {
+        throw new Error(`Happ crypt5 proxy responded with ${response.status}`)
+    }
+
+    const data: unknown = await response.json()
+
+    if (data && typeof data === 'object') {
+        const payload = data as Record<string, unknown>
+        const link = payload.link
+
+        if (typeof link === 'string' && link.startsWith('happ://crypt5/')) {
+            return link
+        }
+    }
+
+    throw new Error('Happ crypt5 proxy returned an invalid link')
 }
 
 export const InstallationGuideConnector = (props: IProps) => {
@@ -80,18 +123,51 @@ export const InstallationGuideConnector = (props: IProps) => {
         window.location.href,
         subscription.user.shortUuid
     )
+    const happCrypt5ApiUrl = joinURL(subscriptionUrl, 'happ-crypt5')
 
-    const handleButtonClick = (button: TSubscriptionPageButtonConfig) => {
-        let formattedUrl: string | undefined
+    const formatButtonUrl = (button: TSubscriptionPageButtonConfig, linkTemplate?: string) => {
+        const template = linkTemplate ?? getButtonLinkTemplate(button) ?? subscriptionUrl
 
-        if (button.type === 'subscriptionLink' || button.type === 'copyButton') {
-            formattedUrl = TemplateEngine.formatWithMetaInfo(button.link, {
-                username: subscription.user.username,
-                subscriptionUrl
-            })
+        return TemplateEngine.formatWithMetaInfo(template, {
+            username: subscription.user.username,
+            subscriptionUrl
+        })
+    }
+
+    const formatButtonUrlAsync = async (button: TSubscriptionPageButtonConfig) => {
+        const linkTemplate = getButtonLinkTemplate(button) ?? subscriptionUrl
+
+        if (!linkTemplate.includes(HAPP_CRYPT5_TEMPLATE)) {
+            return formatButtonUrl(button, linkTemplate)
         }
 
-        switch (button.type) {
+        const happCrypt5Link = await createHappCrypt5Link(happCrypt5ApiUrl, subscriptionUrl)
+        return formatButtonUrl(button, linkTemplate.replaceAll(HAPP_CRYPT5_TEMPLATE, happCrypt5Link))
+    }
+
+    const handleButtonClick = async (button: TSubscriptionPageButtonConfig) => {
+        const buttonType = getButtonType(button)
+        let formattedUrl: string | undefined
+
+        try {
+            if (
+                buttonType === 'subscriptionLink' ||
+                buttonType === 'copyButton' ||
+                HAPP_CRYPT5_BUTTON_TYPES.has(buttonType)
+            ) {
+                formattedUrl = await formatButtonUrlAsync(button)
+            }
+        } catch (error) {
+            notifications.show({
+                title: 'Happ crypt5 link error',
+                message:
+                    error instanceof Error ? error.message : 'Failed to create Happ crypt5 link',
+                color: 'red'
+            })
+            return
+        }
+
+        switch (buttonType) {
             case 'copyButton': {
                 if (!formattedUrl) return
 
@@ -104,7 +180,7 @@ export const InstallationGuideConnector = (props: IProps) => {
                 break
             }
             case 'external': {
-                window.open(button.link, '_blank')
+                window.open(getButtonLinkTemplate(button), '_blank')
                 break
             }
             case 'subscriptionLink': {
@@ -113,8 +189,25 @@ export const InstallationGuideConnector = (props: IProps) => {
                 window.open(formattedUrl, '_blank')
                 break
             }
-            default:
+            default: {
+                if (!HAPP_CRYPT5_BUTTON_TYPES.has(buttonType) || !formattedUrl) break
+
+                try {
+                    const happCrypt5Link = await createHappCrypt5Link(happCrypt5ApiUrl, formattedUrl)
+                    window.open(happCrypt5Link, '_blank')
+                } catch (error) {
+                    notifications.show({
+                        title: 'Happ crypt5 link error',
+                        message:
+                            error instanceof Error
+                                ? error.message
+                                : 'Failed to create Happ crypt5 link',
+                        color: 'red'
+                    })
+                }
+
                 break
+            }
         }
     }
 

--- a/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
+++ b/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
@@ -190,10 +190,16 @@ export const InstallationGuideConnector = (props: IProps) => {
                 break
             }
             default: {
-                if (!HAPP_CRYPT5_BUTTON_TYPES.has(buttonType) || !formattedUrl) break
+                if (!HAPP_CRYPT5_BUTTON_TYPES.has(buttonType)) break
 
                 try {
-                    const happCrypt5Link = await createHappCrypt5Link(happCrypt5ApiUrl, formattedUrl)
+                    const happCrypt5Link =
+                        formattedUrl?.startsWith('happ://crypt5/')
+                            ? formattedUrl
+                            : await createHappCrypt5Link(
+                                  happCrypt5ApiUrl,
+                                  formattedUrl ?? subscriptionUrl
+                              )
                     window.open(happCrypt5Link, '_blank')
                 } catch (error) {
                     notifications.show({


### PR DESCRIPTION
## Summary
- Add Happ crypt5 support for subscription page buttons.
- Support `{{HAPP_CRYPT5_LINK}}` in button link templates.
- Support dedicated button types: `HAPP_CRYPT5_LINK` and `happCrypt5Link`.
- Generate crypt5 links through the subscription-page backend instead of the browser.
- Parse Happ API's actual `encrypted_link` response field, with fallback support for `url`, `link`, and `result`.

## Backend
Adds:

```text
POST /:shortUuid/happ-crypt5