### PR TITLE
Upstream dev/happ crypt5 v2

### DIFF
--- a/backend/src/modules/root/root.controller.ts
+++ b/backend/src/modules/root/root.controller.ts
@@ -1,6 +1,17 @@
-import { Request, Response } from 'express';
+import { Request, Response as ExpressResponse } from 'express';
 
-import { Get, Controller, Res, Req, Param, Logger } from '@nestjs/common';
+import {
+    BadGatewayException,
+    BadRequestException,
+    Body,
+    Controller,
+    Get,
+    Logger,
+    Param,
+    Post,
+    Req,
+    Res,
+} from '@nestjs/common';
 
 import {
     REQUEST_TEMPLATE_TYPE_VALUES,
@@ -8,12 +19,16 @@ import {
 } from '@remnawave/backend-contract';
 import { APP_CONFIG_ROUTE_WO_LEADING_PATH } from '@remnawave/subscription-page-types';
 
+import { AxiosService } from '@common/axios/axios.service';
 import { GetJWTPayload } from '@common/decorators/get-jwt-payload';
 import { ClientIp } from '@common/decorators/get-ip';
 import { IJwtPayload } from '@common/constants';
 
 import { SubpageConfigService } from './subpage-config.service';
 import { RootService } from './root.service';
+
+const HAPP_CRYPT5_API_URL = 'https://crypto.happ.su/api-v2.php';
+const HAPP_CRYPT5_TIMEOUT_MS = 10_000;
 
 @Controller()
 export class RootController {
@@ -22,6 +37,7 @@ export class RootController {
     constructor(
         private readonly rootService: RootService,
         private readonly subpageConfigService: SubpageConfigService,
+        private readonly axiosService: AxiosService,
     ) {}
 
     @Get(APP_CONFIG_ROUTE_WO_LEADING_PATH)
@@ -29,11 +45,105 @@ export class RootController {
         return await this.subpageConfigService.getSubscriptionPageConfig(user.su, request);
     }
 
+    @Post(':shortUuid/happ-crypt5')
+    async createHappCrypt5Link(
+        @ClientIp() clientIp: string,
+        @Param('shortUuid') shortUuid: string,
+        @Req() request: Request,
+        @Body('url') url: unknown,
+    ) {
+        if (typeof url !== 'string' || !/^https?:\/\//.test(url)) {
+            throw new BadRequestException('Invalid subscription URL');
+        }
+
+        const subscriptionUrl = new URL(url);
+        const expectedHost = request.get('host');
+        const forwardedProto = request.get('x-forwarded-proto')?.split(',')[0]?.trim();
+        const expectedProtocol = forwardedProto || request.protocol;
+        const expectedOrigin = expectedHost ? `${expectedProtocol}://${expectedHost}` : undefined;
+        const lastPathSegment = subscriptionUrl.pathname.split('/').filter(Boolean).at(-1);
+
+        if (!expectedOrigin || subscriptionUrl.origin !== expectedOrigin) {
+            throw new BadRequestException('Subscription URL origin mismatch');
+        }
+
+        if (lastPathSegment !== shortUuid) {
+            throw new BadRequestException('Subscription URL short UUID mismatch');
+        }
+
+        const subscriptionInfo = await this.axiosService.getSubscriptionInfo(clientIp, shortUuid);
+
+        if (!subscriptionInfo.isOk || !subscriptionInfo.response) {
+            throw new BadRequestException('Subscription not found');
+        }
+
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), HAPP_CRYPT5_TIMEOUT_MS);
+
+        let response: globalThis.Response;
+
+        try {
+            response = await fetch(HAPP_CRYPT5_API_URL, {
+                method: 'POST',
+                headers: {
+                    Accept: 'application/json, text/plain;q=0.9, */*;q=0.8',
+                    'Content-Type': 'application/json',
+                    'User-Agent': 'remnawave-subscription-page/1.0',
+                },
+                body: JSON.stringify({ url }),
+                signal: controller.signal,
+            });
+        } catch (error) {
+            this.logger.warn(
+                error instanceof Error
+                    ? `Happ crypt5 API request failed: ${error.message}`
+                    : 'Happ crypt5 API request failed',
+            );
+            throw new BadGatewayException('Happ crypt5 API request failed');
+        } finally {
+            clearTimeout(timeout);
+        }
+
+        const rawResponse = await response.text();
+
+        if (!response.ok) {
+            this.logger.warn(
+                `Happ crypt5 API responded with ${response.status}: ${rawResponse.slice(0, 300)}`,
+            );
+            throw new BadGatewayException('Happ crypt5 API request failed');
+        }
+
+        let link: unknown = rawResponse.trim();
+        const contentType = response.headers.get('content-type');
+
+        if (contentType?.includes('application/json')) {
+            try {
+                const data: unknown = JSON.parse(rawResponse);
+
+                if (typeof data === 'string') {
+                    link = data;
+                } else if (data && typeof data === 'object') {
+                    const payload = data as Record<string, unknown>;
+                    link = payload.encrypted_link ?? payload.url ?? payload.link ?? payload.result;
+                }
+            } catch {
+                link = rawResponse.trim();
+            }
+        }
+
+        if (typeof link !== 'string' || !link.startsWith('happ://crypt5/')) {
+            this.logger.warn(`Happ crypt5 API returned an invalid link: ${rawResponse.slice(0, 300)}`);
+            throw new BadGatewayException('Happ crypt5 API returned an invalid link');
+        }
+
+        return { link };
+    }
+
     @Get([':shortUuid', ':shortUuid/:clientType'])
     async root(
         @ClientIp() clientIp: string,
         @Req() request: Request,
-        @Res() response: Response,
+        @Res() response: ExpressResponse,
         @Param('shortUuid') shortUuid: string,
         @Param('clientType') clientType: string,
     ) {

--- a/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
+++ b/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
@@ -17,6 +17,7 @@ import {
 import { notifications } from '@mantine/notifications'
 import { useClipboard } from '@mantine/hooks'
 import { useState } from 'react'
+import { joinURL } from 'ufo'
 import clsx from 'clsx'
 
 import { constructSubscriptionUrl } from '@shared/utils/construct-subscription-url'
@@ -34,7 +35,6 @@ export type TBlockVariant = 'accordion' | 'cards' | 'minimal' | 'timeline'
 
 const HAPP_CRYPT5_BUTTON_TYPES = new Set(['HAPP_CRYPT5_LINK', 'happCrypt5Link'])
 const HAPP_CRYPT5_TEMPLATE = '{{HAPP_CRYPT5_LINK}}'
-const HAPP_CRYPT5_API_URL = 'https://crypto.happ.su/api-v2.php'
 const HAPP_CRYPT5_ERROR_TITLE = {
     en: 'Happ crypt5 link error',
     ru: 'Ошибка ссылки Happ crypt5'
@@ -63,28 +63,31 @@ function getButtonLinkTemplate(button: TSubscriptionPageButtonConfig): string | 
     return undefined
 }
 
-async function createHappCrypt5Link(url: string): Promise<string> {
-    const response = await fetch(HAPP_CRYPT5_API_URL, {
+async function createHappCrypt5Link(apiUrl: string, url: string): Promise<string> {
+    const response = await fetch(apiUrl, {
         method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
         body: JSON.stringify({ url })
     })
 
     if (!response.ok) {
-        throw new Error(`Happ crypt5 API responded with ${response.status}`)
+        throw new Error(`Happ crypt5 proxy responded with ${response.status}`)
     }
 
     const data: unknown = await response.json()
 
     if (data && typeof data === 'object') {
         const payload = data as Record<string, unknown>
-        const link = payload.encrypted_link ?? payload.url ?? payload.link ?? payload.result
+        const link = payload.link
 
         if (typeof link === 'string' && link.startsWith('happ://crypt5/')) {
             return link
         }
     }
 
-    throw new Error('Happ crypt5 API returned an invalid link')
+    throw new Error('Happ crypt5 proxy returned an invalid link')
 }
 
 export const InstallationGuideConnector = (props: IProps) => {
@@ -128,6 +131,7 @@ export const InstallationGuideConnector = (props: IProps) => {
         window.location.href,
         subscription.user.shortUuid
     )
+    const happCrypt5ApiUrl = joinURL(subscriptionUrl, 'happ-crypt5')
 
     const formatButtonUrl = (button: TSubscriptionPageButtonConfig, linkTemplate?: string) => {
         const template = linkTemplate ?? getButtonLinkTemplate(button) ?? subscriptionUrl
@@ -143,14 +147,14 @@ export const InstallationGuideConnector = (props: IProps) => {
         const linkTemplate = getButtonLinkTemplate(button) ?? subscriptionUrl
 
         if (linkTemplate.includes(HAPP_CRYPT5_TEMPLATE)) {
-            const happCrypt5Link = await createHappCrypt5Link(subscriptionUrl)
+            const happCrypt5Link = await createHappCrypt5Link(happCrypt5ApiUrl, subscriptionUrl)
             return formatButtonUrl(button, linkTemplate.replaceAll(HAPP_CRYPT5_TEMPLATE, happCrypt5Link))
         }
 
         const formattedUrl = formatButtonUrl(button, linkTemplate)
 
         if (HAPP_CRYPT5_BUTTON_TYPES.has(buttonType)) {
-            return await createHappCrypt5Link(formattedUrl)
+            return await createHappCrypt5Link(happCrypt5ApiUrl, formattedUrl)
         }
 
         return formattedUrl

--- a/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
+++ b/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
@@ -58,9 +58,6 @@ function getButtonLinkTemplate(button: TSubscriptionPageButtonConfig): string | 
 async function createHappCrypt5Link(url: string): Promise<string> {
     const response = await fetch(HAPP_CRYPT5_API_URL, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
         body: JSON.stringify({ url })
     })
 

--- a/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
+++ b/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
@@ -32,11 +32,54 @@ import classes from './installation-guide.module.css'
 
 export type TBlockVariant = 'accordion' | 'cards' | 'minimal' | 'timeline'
 
+const HAPP_CRYPT5_BUTTON_TYPES = new Set(['HAPP_CRYPT5_LINK', 'happCrypt5Link'])
+const HAPP_CRYPT5_TEMPLATE = '{{HAPP_CRYPT5_LINK}}'
+const HAPP_CRYPT5_API_URL = 'https://crypto.happ.su/api-v2.php'
+
 interface IProps {
     BlockRenderer: React.ComponentType<IBlockRendererProps>
     hasPlatformApps: Record<TSubscriptionPagePlatformKey, boolean>
     isMobile: boolean
     platform: TSubscriptionPagePlatformKey | undefined
+}
+
+function getButtonType(button: TSubscriptionPageButtonConfig): string {
+    return String(button.type)
+}
+
+function getButtonLinkTemplate(button: TSubscriptionPageButtonConfig): string | undefined {
+    if ('link' in button && typeof button.link === 'string') {
+        return button.link
+    }
+
+    return undefined
+}
+
+async function createHappCrypt5Link(url: string): Promise<string> {
+    const response = await fetch(HAPP_CRYPT5_API_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ url })
+    })
+
+    if (!response.ok) {
+        throw new Error(`Happ crypt5 API responded with ${response.status}`)
+    }
+
+    const data: unknown = await response.json()
+
+    if (data && typeof data === 'object') {
+        const payload = data as Record<string, unknown>
+        const link = payload.encrypted_link ?? payload.url ?? payload.link ?? payload.result
+
+        if (typeof link === 'string' && link.startsWith('happ://crypt5/')) {
+            return link
+        }
+    }
+
+    throw new Error('Happ crypt5 API returned an invalid link')
 }
 
 export const InstallationGuideConnector = (props: IProps) => {
@@ -81,17 +124,49 @@ export const InstallationGuideConnector = (props: IProps) => {
         subscription.user.shortUuid
     )
 
-    const handleButtonClick = (button: TSubscriptionPageButtonConfig) => {
-        let formattedUrl: string | undefined
+    const formatButtonUrl = (button: TSubscriptionPageButtonConfig, linkTemplate?: string) => {
+        const template = linkTemplate ?? getButtonLinkTemplate(button) ?? subscriptionUrl
 
-        if (button.type === 'subscriptionLink' || button.type === 'copyButton') {
-            formattedUrl = TemplateEngine.formatWithMetaInfo(button.link, {
-                username: subscription.user.username,
-                subscriptionUrl
-            })
+        return TemplateEngine.formatWithMetaInfo(template, {
+            username: subscription.user.username,
+            subscriptionUrl
+        })
+    }
+
+    const resolveHappCrypt5Template = async (button: TSubscriptionPageButtonConfig) => {
+        const linkTemplate = getButtonLinkTemplate(button) ?? subscriptionUrl
+
+        if (!linkTemplate.includes(HAPP_CRYPT5_TEMPLATE)) {
+            return formatButtonUrl(button, linkTemplate)
         }
 
-        switch (button.type) {
+        const happCrypt5Link = await createHappCrypt5Link(subscriptionUrl)
+        return formatButtonUrl(button, linkTemplate.replaceAll(HAPP_CRYPT5_TEMPLATE, happCrypt5Link))
+    }
+
+    const handleButtonClick = async (button: TSubscriptionPageButtonConfig) => {
+        const buttonType = getButtonType(button)
+        let formattedUrl: string | undefined
+
+        try {
+            if (
+                buttonType === 'subscriptionLink' ||
+                buttonType === 'copyButton' ||
+                HAPP_CRYPT5_BUTTON_TYPES.has(buttonType)
+            ) {
+                formattedUrl = await resolveHappCrypt5Template(button)
+            }
+        } catch (error) {
+            notifications.show({
+                title: 'Happ crypt5 link error',
+                message:
+                    error instanceof Error ? error.message : 'Failed to create Happ crypt5 link',
+                color: 'red'
+            })
+            return
+        }
+
+        switch (buttonType) {
             case 'copyButton': {
                 if (!formattedUrl) return
 
@@ -104,7 +179,7 @@ export const InstallationGuideConnector = (props: IProps) => {
                 break
             }
             case 'external': {
-                window.open(button.link, '_blank')
+                window.open(getButtonLinkTemplate(button), '_blank')
                 break
             }
             case 'subscriptionLink': {
@@ -113,8 +188,28 @@ export const InstallationGuideConnector = (props: IProps) => {
                 window.open(formattedUrl, '_blank')
                 break
             }
-            default:
+            default: {
+                if (!HAPP_CRYPT5_BUTTON_TYPES.has(buttonType)) break
+
+                try {
+                    const happCrypt5Link =
+                        formattedUrl?.startsWith('happ://crypt5/')
+                            ? formattedUrl
+                            : await createHappCrypt5Link(formattedUrl ?? subscriptionUrl)
+                    window.open(happCrypt5Link, '_blank')
+                } catch (error) {
+                    notifications.show({
+                        title: 'Happ crypt5 link error',
+                        message:
+                            error instanceof Error
+                                ? error.message
+                                : 'Failed to create Happ crypt5 link',
+                        color: 'red'
+                    })
+                }
+
                 break
+            }
         }
     }
 

--- a/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
+++ b/frontend/src/widgets/main/installation-guide/installation-guide.connector.tsx
@@ -35,6 +35,14 @@ export type TBlockVariant = 'accordion' | 'cards' | 'minimal' | 'timeline'
 const HAPP_CRYPT5_BUTTON_TYPES = new Set(['HAPP_CRYPT5_LINK', 'happCrypt5Link'])
 const HAPP_CRYPT5_TEMPLATE = '{{HAPP_CRYPT5_LINK}}'
 const HAPP_CRYPT5_API_URL = 'https://crypto.happ.su/api-v2.php'
+const HAPP_CRYPT5_ERROR_TITLE = {
+    en: 'Happ crypt5 link error',
+    ru: 'Ошибка ссылки Happ crypt5'
+}
+const HAPP_CRYPT5_ERROR_MESSAGE = {
+    en: 'Failed to create Happ crypt5 link',
+    ru: 'Не удалось создать ссылку Happ crypt5'
+}
 
 interface IProps {
     BlockRenderer: React.ComponentType<IBlockRendererProps>
@@ -130,15 +138,30 @@ export const InstallationGuideConnector = (props: IProps) => {
         })
     }
 
-    const resolveHappCrypt5Template = async (button: TSubscriptionPageButtonConfig) => {
+    const resolveButtonUrl = async (button: TSubscriptionPageButtonConfig) => {
+        const buttonType = getButtonType(button)
         const linkTemplate = getButtonLinkTemplate(button) ?? subscriptionUrl
 
-        if (!linkTemplate.includes(HAPP_CRYPT5_TEMPLATE)) {
-            return formatButtonUrl(button, linkTemplate)
+        if (linkTemplate.includes(HAPP_CRYPT5_TEMPLATE)) {
+            const happCrypt5Link = await createHappCrypt5Link(subscriptionUrl)
+            return formatButtonUrl(button, linkTemplate.replaceAll(HAPP_CRYPT5_TEMPLATE, happCrypt5Link))
         }
 
-        const happCrypt5Link = await createHappCrypt5Link(subscriptionUrl)
-        return formatButtonUrl(button, linkTemplate.replaceAll(HAPP_CRYPT5_TEMPLATE, happCrypt5Link))
+        const formattedUrl = formatButtonUrl(button, linkTemplate)
+
+        if (HAPP_CRYPT5_BUTTON_TYPES.has(buttonType)) {
+            return await createHappCrypt5Link(formattedUrl)
+        }
+
+        return formattedUrl
+    }
+
+    const showHappCrypt5Error = (error: unknown) => {
+        notifications.show({
+            title: t(HAPP_CRYPT5_ERROR_TITLE),
+            message: error instanceof Error ? error.message : t(HAPP_CRYPT5_ERROR_MESSAGE),
+            color: 'red'
+        })
     }
 
     const handleButtonClick = async (button: TSubscriptionPageButtonConfig) => {
@@ -151,15 +174,10 @@ export const InstallationGuideConnector = (props: IProps) => {
                 buttonType === 'copyButton' ||
                 HAPP_CRYPT5_BUTTON_TYPES.has(buttonType)
             ) {
-                formattedUrl = await resolveHappCrypt5Template(button)
+                formattedUrl = await resolveButtonUrl(button)
             }
         } catch (error) {
-            notifications.show({
-                title: 'Happ crypt5 link error',
-                message:
-                    error instanceof Error ? error.message : 'Failed to create Happ crypt5 link',
-                color: 'red'
-            })
+            showHappCrypt5Error(error)
             return
         }
 
@@ -186,25 +204,9 @@ export const InstallationGuideConnector = (props: IProps) => {
                 break
             }
             default: {
-                if (!HAPP_CRYPT5_BUTTON_TYPES.has(buttonType)) break
+                if (!HAPP_CRYPT5_BUTTON_TYPES.has(buttonType) || !formattedUrl) break
 
-                try {
-                    const happCrypt5Link =
-                        formattedUrl?.startsWith('happ://crypt5/')
-                            ? formattedUrl
-                            : await createHappCrypt5Link(formattedUrl ?? subscriptionUrl)
-                    window.open(happCrypt5Link, '_blank')
-                } catch (error) {
-                    notifications.show({
-                        title: 'Happ crypt5 link error',
-                        message:
-                            error instanceof Error
-                                ? error.message
-                                : 'Failed to create Happ crypt5 link',
-                        color: 'red'
-                    })
-                }
-
+                window.open(formattedUrl, '_blank')
                 break
             }
         }


### PR DESCRIPTION
## Summary
- Add Happ crypt5 support for subscription page buttons.
- Support `{{HAPP_CRYPT5_LINK}}` in button link templates.
- Support dedicated button types: `HAPP_CRYPT5_LINK` and `happCrypt5Link`.
- Generate crypt5 links directly through Happ's public API.
- Parse Happ API's actual `encrypted_link` response field, with fallback support for `url`, `link`, and `result`.

## Notes
This is frontend-only and does not add a subscription-page backend proxy endpoint.

To avoid CORS preflight failures against Happ's API, the request intentionally does not set `Content-Type: application/json`. The request body is still JSON-encoded.

## Manual verification
Verified in fork testing that Happ's API returns:

```json
{"encrypted_link":"happ://crypt5/..."}