### PR TITLE
fix(security): resolve client IP via trusted proxy to prevent spoofing

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,6 +9,15 @@ REMNAWAVE_API_TOKEN=
 # Do not place / at the start/end
 CUSTOM_SUB_PREFIX=
 
+# Number of trusted reverse-proxy hops in front of this app, used to resolve the
+# real client IP. The real IP is forwarded to the Remnawave Panel, so an incorrect
+# value lets clients spoof their IP via X-Forwarded-For.
+#  - 1  -> single reverse proxy (nginx/Caddy/Traefik) - default
+#  - 2  -> two hops, e.g. Cloudflare + nginx
+#  - You can also pass a comma-separated list of trusted proxy IPs/subnets,
+#    e.g. TRUST_PROXY=127.0.0.1,172.16.0.0/12
+TRUST_PROXY=1
+
 # If you use "Caddy with security" addon or "Tiny Auth", you can place here X-Api-Key, which will be applied to requests to Remnawave Panel.
 # Will be used with "X-Api-Key" header
 CADDY_AUTH_API_TOKEN=

--- a/backend/src/common/config/app-config/config.schema.ts
+++ b/backend/src/common/config/app-config/config.schema.ts
@@ -27,6 +27,22 @@ export const configSchema = z
         SUBPAGE_CONFIG_UUID: z.string().default('00000000-0000-0000-0000-000000000000'),
         CUSTOM_SUB_PREFIX: z.optional(z.string()),
 
+        // Number of trusted reverse-proxy hops (e.g. 1 for a single nginx/Caddy,
+        // 2 for Cloudflare + nginx), or a comma-separated list of trusted proxy
+        // IPs/subnets. Used by Express `trust proxy` so the real client IP is
+        // resolved from the trusted hop and cannot be spoofed via X-Forwarded-For.
+        TRUST_PROXY: z
+            .string()
+            .default('1')
+            .transform((val) => (val.trim() === '' ? '1' : val.trim()))
+            .transform((val): boolean | number | string => {
+                if (val === 'true') return true;
+                if (val === 'false') return false;
+                const asNumber = Number(val);
+                if (Number.isInteger(asNumber) && asNumber >= 0) return asNumber;
+                return val;
+            }),
+
         CADDY_AUTH_API_TOKEN: z.optional(z.string()),
         CLOUDFLARE_ZERO_TRUST_CLIENT_ID: z.optional(z.string()),
         CLOUDFLARE_ZERO_TRUST_CLIENT_SECRET: z.optional(z.string()),

--- a/backend/src/common/middlewares/get-real-ip.ts
+++ b/backend/src/common/middlewares/get-real-ip.ts
@@ -1,5 +1,4 @@
 import { NextFunction, Request, Response } from 'express';
-import { getClientIp } from '@kastov/request-ip';
 import morgan from 'morgan';
 
 morgan.token('remote-addr', (req: { clientIp: string } & Request) => {
@@ -11,12 +10,10 @@ export const getRealIp = function (
     res: Response,
     next: NextFunction,
 ) {
-    const ip = getClientIp(req);
-    if (ip) {
-        req.clientIp = ip;
-    } else {
-        req.clientIp = '0.0.0.0';
-    }
+    // `req.ip` is computed by Express from the configured `trust proxy` setting,
+    // so it reflects the real client as seen by the trusted reverse proxy and
+    // cannot be spoofed by a client-supplied X-Forwarded-For / X-Real-IP header.
+    req.clientIp = req.ip || req.socket.remoteAddress || '0.0.0.0';
 
     next();
 };

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -70,6 +70,11 @@ async function bootstrap(): Promise<void> {
 
     app.disable('x-powered-by');
 
+    // Resolve the real client IP from the trusted reverse-proxy hop. Without this,
+    // Express would treat the immediate peer as the client and our IP detection
+    // would rely on raw, client-spoofable forwarding headers.
+    app.set('trust proxy', app.get(TypedConfigService).get('TRUST_PROXY'));
+
     app.use(cookieParser());
 
     app.use(noRobotsMiddleware, proxyCheckMiddleware, checkAssetsCookieMiddleware, getRealIp);


### PR DESCRIPTION
The client IP was derived from raw forwarding headers (X-Forwarded-For / X-Real-IP) via @kastov/request-ip, which ignores Express' trust-proxy boundary and uses the left-most, client-controlled value. That IP is sent to the Remnawave Panel as the real client IP, so a client could spoof it by sending its own X-Forwarded-For header and bypass IP-based controls.

Resolve the IP through Express `trust proxy` instead, so it reflects the client as seen by the trusted reverse proxy and cannot be spoofed.

- add configurable TRUST_PROXY env (hop count, true/false, or CIDR list; default 1) and apply it via app.set('trust proxy', ...)
- derive clientIp from req.ip with socket fallback; drop getClientIp
- document TRUST_PROXY in .env.sample