### PR TITLE
feat: add facebookexternalhit and SteamChat to browser detection

### DIFF
--- a/backend/src/modules/root/root.service.ts
+++ b/backend/src/modules/root/root.service.ts
@@ -151,6 +151,8 @@ export class RootService {
             'Edge',
             'TelegramBot',
             'WhatsApp',
+            'facebookexternalhit',
+            'SteamChat',
         ];
 
         return browserKeywords.some((keyword) => userAgent.includes(keyword));


### PR DESCRIPTION
В списках браузеров есть TelegramBot и WhatsApp, чтобы мессенджеры получали HTML-страницу с meta-тегами, а не конфиг подписки прямо в превью чата. В логах замечал facebookexternalhit и SteamChat, они под текущие браузерные фильтры не попадают. Оба так же получают с целью превью в чатах