### PR TITLE
feat: add facebookexternalhit and SteamChat to browser detection

### DIFF
--- a/backend/src/common/decorators/is-browser/is-browser.ts
+++ b/backend/src/common/decorators/is-browser/is-browser.ts
@@ -11,6 +11,8 @@ const BROWSER_KEYWORDS = [
     'Edge',
     'TelegramBot',
     'WhatsApp',
+    'facebookexternalhit',
+    'SteamChat',
 ];
 
 export const IsBrowser = createParamDecorator((data: unknown, ctx: ExecutionContext): boolean => {


### PR DESCRIPTION
В списках браузеров есть TelegramBot и WhatsApp, чтобы мессенджеры получали HTML-страницу с meta-тегами, а не конфиг подписки прямо в превью чата. В логах замечал facebookexternalhit и SteamChat, они под текущие браузерные фильтры не попадают. Оба так же получают с целью превью в чатах